### PR TITLE
Basic search with search API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,11 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/entity_browser": "^2.5",
+        "drupal/facets": "^1.5",
         "drupal/field_group": "~3.0",
         "drupal/pathauto": "~1.0",
+        "drupal/search_api": "^1.17",
+        "drupal/search_api_autocomplete": "^1.3",
         "localgovdrupal/localgov_topics": "^1.0@alpha",
         "localgovdrupal/localgov_core": "^1.0@alpha"
     }

--- a/config/install/core.entity_view_display.node.localgov_news_article.search_index.yml
+++ b/config/install/core.entity_view_display.node.localgov_news_article.search_index.yml
@@ -1,0 +1,38 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_index
+    - field.field.node.localgov_news_article.body
+    - field.field.node.localgov_news_article.localgov_news_categories
+    - field.field.node.localgov_news_article.localgov_news_date
+    - field.field.node.localgov_news_article.localgov_news_default_image
+    - field.field.node.localgov_news_article.localgov_news_image
+    - field.field.node.localgov_news_article.localgov_news_related
+    - node.type.localgov_news_article
+  enforced:
+    module:
+      - localgov_news
+  module:
+    - text
+    - user
+id: node.localgov_news_article.search_index
+targetEntityType: node
+bundle: localgov_news_article
+mode: search_index
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  links: true
+  localgov_news_categories: true
+  localgov_news_date: true
+  localgov_news_default_image: true
+  localgov_news_image: true
+  localgov_news_related: true
+  search_api_excerpt: true

--- a/config/install/facets.facet.localgov_news_category.yml
+++ b/config/install/facets.facet.localgov_news_category.yml
@@ -1,0 +1,55 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.localgov_news
+    - views.view.localgov_news_search
+  module:
+    - search_api
+id: localgov_news_category
+name: Category
+url_alias: category
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: localgov_news_categories
+facet_source_id: 'search_api:views_page__localgov_news_search__page_search_news'
+widget:
+  type: checkbox
+  config:
+    show_numbers: true
+    soft_limit: 0
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: true
+    reset_text: 'All categories'
+    hide_reset_when_no_selection: true
+query_operator: or
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: false
+processor_configs:
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: ASC
+  translate_entity:
+    processor_id: translate_entity
+    weights:
+      build: 5
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: true

--- a/config/install/facets.facet.localgov_news_category.yml
+++ b/config/install/facets.facet.localgov_news_category.yml
@@ -4,6 +4,9 @@ dependencies:
   config:
     - search_api.index.localgov_news
     - views.view.localgov_news_search
+  enforced:
+    module:
+      - localgov_news
   module:
     - search_api
 id: localgov_news_category

--- a/config/install/facets.facet.localgov_news_date.yml
+++ b/config/install/facets.facet.localgov_news_date.yml
@@ -4,6 +4,9 @@ dependencies:
   config:
     - search_api.index.localgov_news
     - views.view.localgov_news_search
+  enforced:
+    module:
+      - localgov_news
   module:
     - search_api
 id: localgov_news_date

--- a/config/install/facets.facet.localgov_news_date.yml
+++ b/config/install/facets.facet.localgov_news_date.yml
@@ -1,0 +1,58 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.localgov_news
+    - views.view.localgov_news_search
+  module:
+    - search_api
+id: localgov_news_date
+name: Date
+url_alias: date
+weight: 0
+min_count: 1
+show_only_one_result: false
+field_identifier: localgov_news_date
+facet_source_id: 'search_api:views_page__localgov_news_search__page_search_news'
+widget:
+  type: checkbox
+  config:
+    show_numbers: true
+    soft_limit: 0
+    soft_limit_settings:
+      show_less_label: 'Show less'
+      show_more_label: 'Show more'
+    show_reset_link: false
+    reset_text: 'Show all'
+    hide_reset_when_no_selection: false
+query_operator: or
+use_hierarchy: false
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
+only_visible_when_facet_source_is_visible: false
+processor_configs:
+  date_item:
+    processor_id: date_item
+    weights:
+      build: 35
+    settings:
+      date_display: actual_date
+      granularity: 6
+      date_format: ''
+  display_value_widget_order:
+    processor_id: display_value_widget_order
+    weights:
+      sort: 40
+    settings:
+      sort: DESC
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/config/install/facets.facet.localgov_news_date.yml
+++ b/config/install/facets.facet.localgov_news_date.yml
@@ -22,9 +22,9 @@ widget:
     soft_limit_settings:
       show_less_label: 'Show less'
       show_more_label: 'Show more'
-    show_reset_link: false
-    reset_text: 'Show all'
-    hide_reset_when_no_selection: false
+    show_reset_link: true
+    reset_text: 'All years'
+    hide_reset_when_no_selection: true
 query_operator: or
 use_hierarchy: false
 expand_hierarchy: false
@@ -55,4 +55,4 @@ processor_configs:
     settings: {  }
 empty_behavior:
   behavior: none
-show_title: false
+show_title: true

--- a/config/install/search_api.index.localgov_news.yml
+++ b/config/install/search_api.index.localgov_news.yml
@@ -7,8 +7,8 @@ dependencies:
     - search_api.server.localgov_news
     - core.entity_view_mode.node.search_index
   module:
-    - search_api
     - node
+    - search_api
 id: localgov_news
 name: News
 description: ''
@@ -19,7 +19,6 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: localgov_news_categories
     type: integer
-    boost: 0.5
     dependencies:
       config:
         - field.storage.node.localgov_news_categories
@@ -40,7 +39,15 @@ field_settings:
         anonymous: anonymous
       view_mode:
         'entity:node':
-          localgov_news: search_index
+          localgov_news_article: search_index
+  title:
+    label: Title
+    datasource_id: 'entity:node'
+    property_path: title
+    type: string
+    dependencies:
+      module:
+        - node
 datasource_settings:
   'entity:node':
     bundles:
@@ -58,7 +65,8 @@ processor_settings:
     all_fields: true
     fields:
       - rendered_item
-    title: true
+      - title
+    title: false
     alt: true
     tags:
       b: 2
@@ -75,6 +83,7 @@ processor_settings:
     all_fields: true
     fields:
       - rendered_item
+      - title
     weights:
       preprocess_index: -20
       preprocess_query: -20
@@ -148,6 +157,7 @@ processor_settings:
     all_fields: true
     fields:
       - rendered_item
+      - title
     weights:
       preprocess_index: -20
       preprocess_query: -20

--- a/config/install/search_api.index.localgov_news.yml
+++ b/config/install/search_api.index.localgov_news.yml
@@ -1,0 +1,161 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_news_categories
+    - field.storage.node.localgov_news_date
+    - search_api.server.localgov_news
+    - core.entity_view_mode.node.search_index
+  module:
+    - search_api
+    - node
+id: localgov_news
+name: News
+description: ''
+read_only: false
+field_settings:
+  localgov_news_categories:
+    label: Categories
+    datasource_id: 'entity:node'
+    property_path: localgov_news_categories
+    type: integer
+    boost: 0.5
+    dependencies:
+      config:
+        - field.storage.node.localgov_news_categories
+  localgov_news_date:
+    label: Date
+    datasource_id: 'entity:node'
+    property_path: localgov_news_date
+    type: date
+    dependencies:
+      config:
+        - field.storage.node.localgov_news_date
+  rendered_item:
+    label: 'Rendered HTML output'
+    property_path: rendered_item
+    type: text
+    configuration:
+      roles:
+        anonymous: anonymous
+      view_mode:
+        'entity:node':
+          localgov_news: search_index
+datasource_settings:
+  'entity:node':
+    bundles:
+      default: false
+      selected:
+        - localgov_news_article
+        - localgov_newsroom
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  add_url: {  }
+  aggregated_field: {  }
+  entity_status: {  }
+  html_filter:
+    all_fields: true
+    fields:
+      - rendered_item
+    title: true
+    alt: true
+    tags:
+      b: 2
+      em: 1
+      h1: 5
+      h2: 3
+      h3: 2
+      strong: 2
+      u: 1
+    weights:
+      preprocess_index: -15
+      preprocess_query: -15
+  ignorecase:
+    all_fields: true
+    fields:
+      - rendered_item
+    weights:
+      preprocess_index: -20
+      preprocess_query: -20
+  language_with_fallback: {  }
+  rendered_item: {  }
+  stemmer:
+    all_fields: true
+    fields:
+      - rendered_item
+    exceptions:
+      mexican: mexic
+      texan: texa
+    weights:
+      preprocess_index: 0
+      preprocess_query: 0
+  stopwords:
+    all_fields: true
+    fields:
+      - rendered_item
+    stopwords:
+      - a
+      - an
+      - and
+      - are
+      - as
+      - at
+      - be
+      - but
+      - by
+      - for
+      - if
+      - in
+      - into
+      - is
+      - it
+      - 'no'
+      - not
+      - of
+      - 'on'
+      - or
+      - s
+      - such
+      - t
+      - that
+      - the
+      - their
+      - then
+      - there
+      - these
+      - they
+      - this
+      - to
+      - was
+      - will
+      - with
+    weights:
+      preprocess_index: -5
+      preprocess_query: -2
+  tokenizer:
+    all_fields: true
+    fields:
+      - rendered_item
+    ignored: ._-
+    spaces: ''
+    overlap_cjk: 1
+    minimum_word_size: '3'
+    weights:
+      preprocess_index: -6
+      preprocess_query: -6
+  transliteration:
+    all_fields: true
+    fields:
+      - rendered_item
+    weights:
+      preprocess_index: -20
+      preprocess_query: -20
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  index_directly: true
+  cron_limit: 50
+server: localgov_news

--- a/config/install/search_api.index.localgov_news.yml
+++ b/config/install/search_api.index.localgov_news.yml
@@ -9,6 +9,9 @@ dependencies:
   module:
     - node
     - search_api
+  enforced:
+    module:
+      - localgov_news
 id: localgov_news
 name: News
 description: ''

--- a/config/install/search_api.index.localgov_news.yml
+++ b/config/install/search_api.index.localgov_news.yml
@@ -47,7 +47,6 @@ datasource_settings:
       default: false
       selected:
         - localgov_news_article
-        - localgov_newsroom
     languages:
       default: true
       selected: {  }

--- a/config/install/search_api.server.localgov_news.yml
+++ b/config/install/search_api.server.localgov_news.yml
@@ -3,6 +3,9 @@ status: true
 dependencies:
   module:
     - search_api_db
+  enforced:
+    module:
+      - localgov_news
 id: localgov_news
 name: News
 description: 'Default news search server. For convenience of installation. Can be used or replaced.'

--- a/config/install/search_api.server.localgov_news.yml
+++ b/config/install/search_api.server.localgov_news.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - search_api_db
+id: localgov_news
+name: News
+description: 'Default news search server. For convenience of installation. Can be used or replaced.'
+backend: search_api_db
+backend_config:
+  database: 'default:default'
+  min_chars: 3
+  matching: prefix
+  autocomplete:
+    suggest_suffix: true
+    suggest_words: true

--- a/config/install/search_api_autocomplete.search.localgov_news_search.yml
+++ b/config/install/search_api_autocomplete.search.localgov_news_search.yml
@@ -4,6 +4,9 @@ dependencies:
   config:
     - search_api.index.localgov_news
     - views.view.localgov_news_search
+  enforced:
+    module:
+      - localgov_news
   module:
     - views
     - search_api_autocomplete

--- a/config/install/search_api_autocomplete.search.localgov_news_search.yml
+++ b/config/install/search_api_autocomplete.search.localgov_news_search.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.localgov_news
+    - views.view.localgov_news_search
+  module:
+    - views
+    - search_api_autocomplete
+id: localgov_news_search
+label: 'News search'
+index_id: localgov_news
+suggester_settings:
+  live_results:
+    fields: {  }
+    view_modes: {  }
+suggester_weights: {  }
+suggester_limits: {  }
+search_settings:
+  'views:localgov_news_search':
+    displays:
+      default: true
+      selected: {  }
+options: {  }

--- a/config/install/views.view.localgov_news_search.yml
+++ b/config/install/views.view.localgov_news_search.yml
@@ -222,9 +222,9 @@ display:
       tags:
         - 'config:field.storage.node.localgov_news_categories'
         - 'config:search_api.index.localgov_news'
-  localgov_news_search:
+  page_search_news:
     display_plugin: page
-    id: localgov_news_search
+    id: page_search_news
     display_title: Page
     position: 1
     display_options:

--- a/config/install/views.view.localgov_news_search.yml
+++ b/config/install/views.view.localgov_news_search.yml
@@ -27,7 +27,7 @@ display:
         type: none
         options: {  }
       cache:
-        type: tag
+        type: none
         options: {  }
       query:
         type: views_query

--- a/config/install/views.view.localgov_news_search.yml
+++ b/config/install/views.view.localgov_news_search.yml
@@ -210,7 +210,20 @@ display:
       title: 'News search'
       header: {  }
       footer: {  }
-      empty: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'There were no results found for your search.'
+            format: wysiwyg
+          plugin_id: text
       relationships: {  }
       arguments: {  }
       display_extenders: {  }

--- a/config/install/views.view.localgov_news_search.yml
+++ b/config/install/views.view.localgov_news_search.yml
@@ -6,6 +6,9 @@ dependencies:
     - search_api.index.localgov_news
   module:
     - search_api
+  enforced:
+    module:
+      - localgov_news
 id: localgov_news_search
 label: 'News search'
 module: views

--- a/config/install/views.view.localgov_news_search.yml
+++ b/config/install/views.view.localgov_news_search.yml
@@ -2,28 +2,17 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.body
-    - field.storage.node.localgov_news_date
-    - field.storage.node.localgov_news_image
-    - image.style.localgov_newsroom_teaser
-    - node.type.localgov_news_article
-    - taxonomy.vocabulary.localgov_topic
+    - field.storage.node.localgov_news_categories
+    - search_api.index.localgov_news
   module:
-    - datetime
-    - media
-    - node
-    - taxonomy
-    - text
-    - user
-_core:
-  default_config_hash: 7TKHqB69TKAsOGaQ2PGvc1IrFW7Ik6CmgFd1NXu2P5g
+    - search_api
 id: localgov_news_search
 label: 'News search'
 module: views
-description: 'News search view'
+description: ''
 tag: ''
-base_table: node_field_data
-base_field: nid
+base_table: search_api_index_localgov_news
+base_field: search_api_id
 display:
   default:
     display_plugin: default
@@ -32,24 +21,21 @@ display:
     position: 0
     display_options:
       access:
-        type: perm
-        options:
-          perm: 'access content'
+        type: none
+        options: {  }
       cache:
         type: tag
         options: {  }
       query:
         type: views_query
         options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
+          bypass_access: false
+          skip_access: false
+          preserve_facet_query_args: false
       exposed_form:
         type: basic
         options:
-          submit_button: 'Search news'
+          submit_button: Apply
           reset_button: false
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
@@ -59,7 +45,7 @@ display:
       pager:
         type: full
         options:
-          items_per_page: 20
+          items_per_page: 10
           offset: 0
           id: 0
           total_pages: null
@@ -80,21 +66,19 @@ display:
       style:
         type: default
       row:
-        type: fields
+        type: search_api
         options:
-          default_field_elements: true
-          inline:
-            localgov_news_image: localgov_news_image
-            title: title
-            body: body
-            localgov_news_date: localgov_news_date
-          separator: ''
-          hide_empty: false
+          view_modes:
+            'entity:node':
+              localgov_news_article: teaser
       fields:
-        localgov_news_image:
-          id: localgov_news_image
-          table: node__localgov_news_image
-          field: localgov_news_image
+        localgov_news_categories:
+          table: search_api_index_localgov_news
+          field: localgov_news_categories
+          id: localgov_news_categories
+          entity_type: null
+          entity_field: null
+          plugin_id: search_api_field
           relationship: none
           group_type: group
           admin_label: ''
@@ -131,7 +115,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: false
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -140,10 +124,8 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: target_id
-          type: media_thumbnail
-          settings:
-            image_style: localgov_newsroom_teaser
-            image_link: content
+          type: entity_reference_label
+          settings: {  }
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -154,246 +136,35 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: false
-            ellipsis: false
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: h2
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
-        body:
-          id: body
-          table: node__body
-          field: body
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: text_summary_or_trimmed
-          settings:
-            trim_length: 200
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-        localgov_news_date:
-          id: localgov_news_date
-          table: node__localgov_news_date
-          field: localgov_news_date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: datetime_custom
-          settings:
-            timezone_override: ''
-            date_format: 'j F Y'
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods: {  }
       filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          value:
-            localgov_news_article: localgov_news_article
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        combine:
-          id: combine
-          table: views
-          field: combine
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_localgov_news
+          field: search_api_fulltext
           relationship: none
           group_type: group
           admin_label: ''
-          operator: allwords
+          operator: or
           value: ''
           group: 1
           exposed: true
           expose:
-            operator_id: combine_op
+            operator_id: search_api_fulltext_op
             label: Search
             description: ''
             use_operator: false
-            operator: combine_op
+            operator: search_api_fulltext_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: search_text
+            identifier: search_api_fulltext
             required: false
             remember: false
             multiple: false
@@ -402,6 +173,8 @@ display:
               anonymous: '0'
               localgov_news_editor: '0'
             placeholder: ''
+            expose_fields: false
+            searched_fields_id: search_api_fulltext_searched_fields
           is_grouped: false
           group_info:
             label: ''
@@ -414,62 +187,15 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          fields:
-            title: title
-            body: body
-          plugin_id: combine
-        localgov_news_categories_target_id:
-          id: localgov_news_categories_target_id
-          table: node__localgov_news_categories
-          field: localgov_news_categories_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: localgov_news_categories_target_id_op
-            label: Category
-            description: ''
-            use_operator: false
-            operator: localgov_news_categories_target_id_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: localgov_news_categories_target_id
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              localgov_news_editor: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: localgov_topic
-          hierarchy: false
-          error_message: true
-          plugin_id: taxonomy_index_tid
+          parse_mode: terms
+          min_length: null
+          fields: {  }
+          plugin_id: search_api_fulltext
       sorts:
-        localgov_news_date_value:
-          id: localgov_news_date_value
-          table: node__localgov_news_date
-          field: localgov_news_date_value
+        localgov_news_date:
+          id: localgov_news_date
+          table: search_api_index_localgov_news
+          field: localgov_news_date
           relationship: none
           group_type: group
           admin_label: ''
@@ -477,32 +203,14 @@ display:
           exposed: false
           expose:
             label: ''
-          granularity: second
-          plugin_id: datetime
+          plugin_id: search_api
       title: 'News search'
       header: {  }
       footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '<p>No results found.</p>'
-            format: wysiwyg
-          plugin_id: text
+      empty: {  }
       relationships: {  }
       arguments: {  }
       display_extenders: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
     cache_metadata:
       max-age: -1
       contexts:
@@ -510,16 +218,13 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
-        - user.permissions
       tags:
-        - 'config:field.storage.node.body'
-        - 'config:field.storage.node.localgov_news_date'
-        - 'config:field.storage.node.localgov_news_image'
-  page_search_news:
+        - 'config:field.storage.node.localgov_news_categories'
+        - 'config:search_api.index.localgov_news'
+  localgov_news_search:
     display_plugin: page
-    id: page_search_news
+    id: localgov_news_search
     display_title: Page
     position: 1
     display_options:
@@ -533,10 +238,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
-        - user.permissions
       tags:
-        - 'config:field.storage.node.body'
-        - 'config:field.storage.node.localgov_news_date'
-        - 'config:field.storage.node.localgov_news_image'
+        - 'config:field.storage.node.localgov_news_categories'
+        - 'config:search_api.index.localgov_news'

--- a/config/optional/block.block.localgov_news_category.yml
+++ b/config/optional/block.block.localgov_news_category.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.localgov_news_category
+  module:
+    - facets
+    - system
+  theme:
+    - localgov_theme
+id: localgov_news_category
+theme: localgov_theme
+region: sidebar_second
+weight: 0
+provider: null
+plugin: 'facet_block:localgov_news_category'
+settings:
+  id: 'facet_block:localgov_news_category'
+  label: Category
+  provider: facets
+  label_display: '0'
+  block_id: localgov_news_category
+visibility:
+  request_path:
+    id: request_path
+    pages: "/news\r\n/news/*"
+    negate: false
+    context_mapping: {  }

--- a/config/optional/block.block.localgov_news_date.yml
+++ b/config/optional/block.block.localgov_news_date.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - facets.facet.localgov_news_date
+  module:
+    - facets
+    - system
+  theme:
+    - localgov_theme
+id: localgov_news_date
+theme: localgov_theme
+region: sidebar_second
+weight: 0
+provider: null
+plugin: 'facet_block:localgov_news_date'
+settings:
+  id: 'facet_block:localgov_news_date'
+  label: News date
+  provider: facets
+  label_display: visible
+  block_id: localgov_news_date
+visibility:
+  request_path:
+    id: request_path
+    pages: "/news\r\n/news/*"
+    negate: false
+    context_mapping: {  }

--- a/localgov_news.info.yml
+++ b/localgov_news.info.yml
@@ -19,3 +19,6 @@ dependencies:
   - link_attributes:link_attributes
   - localgov_core:localgov_core
   - pathauto:pathauto
+  - search_api:search_api
+  - search_api:search_api_db
+  - search_api_autocomplete

--- a/localgov_news.info.yml
+++ b/localgov_news.info.yml
@@ -15,6 +15,7 @@ dependencies:
   - drupal:text
   - drupal:user
   - entity_browser:entity_browser
+  - facets:facets
   - field_group:field_group
   - link_attributes:link_attributes
   - localgov_core:localgov_core

--- a/localgov_news.install
+++ b/localgov_news.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the localgov_news module.
+ */
+
+use Drupal\user\RoleInterface;
+
+/**
+ * Implements hook_install().
+ */
+function localgov_news_install() {
+  if (\Drupal::moduleHandler()->moduleExists('user')) {
+    user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['use search_api_autocomplete for localgov_news_search']);
+  }
+}


### PR DESCRIPTION
Full text search for news with autocomplete using search API. This PR:

- Adds search server for news.
- Adds search index for news articles.
- Adds search index entity view display.
- Updates news search block to provide text search backed by index.
- Implements auto-complete, displaying titles of news articles matching input.
- Adds facets and blocks for date and category

Closes #7 Closes #9 