### PR TITLE
Feature/5 news schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Test LocalGov Drupal Demo
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    name: 'Execute run-tests.sh'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
+      - name: Clone drupal-container
+        uses: actions/checkout@v2
+        with:
+          repository: localgovdrupal/drupal-container
+          ref: master
+
+      - name: Create LocalGov Drupal project
+        run: composer create-project --stability dev localgovdrupal/localgov-project html
+
+      - name: Save git branch and git repo names to env if not a pull request
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "GIT_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "GIT_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+
+      - name: Save git branch and git repo names to env if is a pull request
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "GIT_BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "GIT_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+
+      - name: Setup package source and authentication for the test target
+        run: |
+          composer --working-dir=html config repositories.1 vcs git@github.com:${GIT_REPO}.git
+          composer global config github-oauth.github.com ${{ github.token }}
+
+      - name: Grab test target from this repo
+        run: composer --working-dir=html require localgovdrupal/${{ github.event.repository.name }}:"dev-${GIT_BRANCH} as 1.0.x-dev"
+
+      - name: Start Docker environment
+        run: docker-compose up -d
+
+      - name: Run tests
+        run: ./run-tests.sh
+        shell: bash

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "drupal/pathauto": "~1.0",
         "drupal/search_api": "^1.17",
         "drupal/search_api_autocomplete": "^1.3",
+        "drupal/schema_metatag": "^2.1",
         "localgovdrupal/localgov_topics": "^1.0@alpha",
         "localgovdrupal/localgov_core": "^1.0@alpha"
     }

--- a/config/install/metatag.metatag_defaults.node__localgov_news_article.yml
+++ b/config/install/metatag.metatag_defaults.node__localgov_news_article.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__localgov_news_article
+label: 'Content: News article'
+tags:
+  schema_article_about: '[node:localgov_news_categories:0:entity]'
+  schema_article_author: 'a:4:{s:5:"@type";s:12:"Organization";s:3:"@id";s:10:"[site:url]";s:4:"name";s:11:"[site:name]";s:3:"url";s:10:"[site:url]";}'
+  schema_article_date_modified: '[node:changed:custom:Y-m-d]'
+  schema_article_date_published: '[node:localgov_news_date:date:custom:Y-m-d]'
+  schema_article_description: '[node:summary]'
+  schema_article_has_part: 'a:2:{s:5:"@type";s:14:"WebPageElement";s:19:"isAccessibleForFree";s:4:"True";}'
+  schema_article_headline: '[node:title]'
+  schema_article_image: 'a:5:{s:5:"@type";s:11:"ImageObject";s:20:"representativeOfPage";s:4:"True";s:3:"url";s:51:"[node:localgov_news_image:entity:field_media_image]";s:5:"width";s:57:"[node:localgov_news_image:entity:field_media_image:width]";s:6:"height";s:58:"[node:localgov_news_image:entity:field_media_image:height]";}'
+  schema_article_is_accessible_for_free: 'True'
+  schema_article_main_entity_of_page: '[node:url]'
+  schema_article_name: '[node:title]'
+  schema_article_publisher: 'a:4:{s:5:"@type";s:12:"Organization";s:3:"@id";s:10:"[site:url]";s:4:"name";s:11:"[site:name]";s:3:"url";s:10:"[site:url]";}'
+  schema_article_type: NewsArticle

--- a/localgov_news.info.yml
+++ b/localgov_news.info.yml
@@ -22,6 +22,6 @@ dependencies:
   - pathauto:pathauto
   - search_api:search_api
   - search_api:search_api_db
-  - search_api_autocomplete
+  - search_api_autocomplete:search_api_autocomplete
   - schema_metatag:schema_metatag
   - schema_metatag:schema_article

--- a/localgov_news.info.yml
+++ b/localgov_news.info.yml
@@ -23,3 +23,5 @@ dependencies:
   - search_api:search_api
   - search_api:search_api_db
   - search_api_autocomplete
+  - schema_metatag:schema_metatag
+  - schema_metatag:schema_article

--- a/localgov_news.module
+++ b/localgov_news.module
@@ -144,7 +144,7 @@ function localgov_news_entity_extra_field_info() {
  * Implements hook_tokens_alter().
  */
 function localgov_news_tokens_alter(&$replacements, $context) {
-  // Encode commas in news categories so they are not split.
+  // Remove commas in news categories so they are not split.
   if ($context['type'] == 'node') {
     if (isset($replacements['[node:localgov_news_categories:0:entity]'])) {
       $replacements['[node:localgov_news_categories:0:entity]'] = stripslashes(str_replace(',', '', $replacements['[node:localgov_news_categories:0:entity]']));

--- a/localgov_news.module
+++ b/localgov_news.module
@@ -144,7 +144,7 @@ function localgov_news_entity_extra_field_info() {
  * Implements hook_tokens_alter().
  */
 function localgov_news_tokens_alter(&$replacements, $context) {
-  // Encode commas in news categories to ensure they are not split by token processing
+  // Encode commas in news categories so they are not split.
   if ($context['type'] == 'node') {
     if (isset($replacements['[node:localgov_news_categories:0:entity]'])) {
       $replacements['[node:localgov_news_categories:0:entity]'] = stripslashes(str_replace(',', '', $replacements['[node:localgov_news_categories:0:entity]']));

--- a/localgov_news.module
+++ b/localgov_news.module
@@ -139,3 +139,15 @@ function localgov_news_entity_extra_field_info() {
 
   return $extra_field;
 }
+
+/**
+ * Implements hook_tokens_alter().
+ */
+function localgov_news_tokens_alter(&$replacements, $context) {
+  // Encode commas in news categories to ensure they are not split by token processing
+  if ($context['type'] == 'node') {
+    if (isset($replacements['[node:localgov_news_categories:0:entity]'])) {
+      $replacements['[node:localgov_news_categories:0:entity]'] = stripslashes(str_replace(',', '', $replacements['[node:localgov_news_categories:0:entity]']));
+    }
+  }
+}

--- a/modules/localgov_newsroom/src/Newsroom.php
+++ b/modules/localgov_newsroom/src/Newsroom.php
@@ -67,7 +67,8 @@ class Newsroom {
    * @return array
    *   Node IDs to exclude (visible in featured block)
    *
-   * @throws
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   private function excludeNodes() {
     $nodes = [];

--- a/tests/src/Functional/NewsPageTest.php
+++ b/tests/src/Functional/NewsPageTest.php
@@ -16,7 +16,6 @@ use Drupal\Tests\node\Traits\NodeCreationTrait;
 class NewsPageTest extends BrowserTestBase {
 
   use NodeCreationTrait;
-  use AssertBreadcrumbTrait;
 
   /**
    * Test breadcrumbs in the Standard profile.

--- a/tests/src/Functional/NewsPageTest.php
+++ b/tests/src/Functional/NewsPageTest.php
@@ -7,7 +7,6 @@ use Drupal\media\Entity\Media;
 use Drupal\node\NodeInterface;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
-use Drupal\Tests\system\Functional\Menu\AssertBreadcrumbTrait;
 
 /**
  * Tests LocalGov News article page.


### PR DESCRIPTION
This PR adds the [NewsArticle schema](https://schema.org/NewsArticle) to LocalGov Drupal news articles, as JSON-LD in the document <head>. Closes #5 

Validated against Google's [Rich Results Test Tool](https://search.google.com/test/rich-results), using local tests and this publicly accessible example:

- ["Heartbreaking" - statement on new national lockdown](https://dev.londoncouncils.gov.uk/news/2021/heartbreaking-statement-new-national-lockdown)

Validation results:

- https://search.google.com/test/rich-results?id=eMEH--GY4w_looLnOzFDWw

Notes:

- The 'about' element only includes the first category related to a news article.
- If the category contains a comma, the category is exploded into multiple 'about' elements which expects a comma-delimited list of terms. As a temporary fix the module removes commas from categories using hook_tokens_alter()
- Uses the source image URL at full resolution (it's the responsibility of consuming services to resize the image if required).