### PR TITLE
Remove newsroom thumbnails from nav flow

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_news_article.teaser.yml
+++ b/config/install/core.entity_view_display.node.localgov_news_article.teaser.yml
@@ -50,7 +50,7 @@ content:
     label: hidden
     settings:
       image_style: localgov_newsroom_teaser
-      image_link: content
+      image_link: ''
     third_party_settings: {  }
 hidden:
   links: true

--- a/templates/node--localgov-news-article--teaser.html.twig
+++ b/templates/node--localgov-news-article--teaser.html.twig
@@ -77,7 +77,7 @@
 ]
 %}
 <article{{ attributes.addClass(classes) }}>
-    {{ content.localgov_news_image }}
+  <a href="{{ url }}" tabindex="-1">{{ content.localgov_news_image }}</a>
   <div{{ content_attributes.addClass('node__content') }}>
     <h3>
       <a href="{{ url }}">{{ label }}</a>


### PR DESCRIPTION
This PR closes #20:

- Removes the link from the news article view display teaser image
- Adds the link back in the teaser template, with a tabindex of -1