### PR TITLE
udpate News template to follow Drupal standards more closely

### DIFF
--- a/templates/node--localgov-news-article--full.html.twig
+++ b/templates/node--localgov-news-article--full.html.twig
@@ -1,7 +1,6 @@
 {#
 /**
  * @file
- * Bartik's theme implementation to display a node.
  *
  * Available variables:
  * - node: The node entity with limited access to object properties and methods.
@@ -83,18 +82,18 @@
 
   <div class="news-article__metadata">
     <time datetime="{{ node.localgov_news_date()|date("U") }}" class="news-article__metadata-item news-article__metadata--date">
-      {{ node.localgov_news_date()|date("j F Y") }}
+      {{ content.localgov_news_date }}
     </time>
-    {% if not node.localgov_news_categories.isEmpty() %}
-      {% for item in node.localgov_news_categories %}
-        <ul class="news-article__metadata-item news-article__metadata--categories">
+    {% if node.localgov_news_categories.value %}
+      <ul class="news-article__metadata-item news-article__metadata--categories">
+        {% for item in node.localgov_news_categories %}
           <li class="news-article__category">
-            <a href="{{ path('entity.taxonomy_term.canonical', {'taxonomy_term': item.entity.id()}) }}">
+            <a href="/news/search?f[0]=category:{{ item.target_id }}">
               {{ item.entity.label() }}
             </a>
           </li>
-        </ul>
-      {% endfor %}
+        {% endfor %}
+      </ul>
     {% endif %}
   </div>
 
@@ -103,7 +102,7 @@
   </h1>
 
   <div{{ content_attributes.addClass('news-article__content node__content') }}>
-    {{ content }}
+    {{ content|without('localgov_news_date') }}
   </div>
 
 </article>

--- a/templates/node--localgov-news-article--full.html.twig
+++ b/templates/node--localgov-news-article--full.html.twig
@@ -67,23 +67,41 @@
  */
 #}
 
-<article{{ content_attributes.addClass('content').addClass('newsroom--article') }}>
-  <div>
-    <div class="newsroom--info">
-      <span class="newsroom--date">{{ node.localgov_news_date()|date("j F Y") }}</span>
+{%
+  set classes = [
+    'news-article',
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
 
-      {% if not node.localgov_news_categories.isEmpty() %}
-        <span class="newsroom--category">
-        <a href="{{ path('entity.taxonomy_term.canonical', {'taxonomy_term': node.localgov_news_categories.entity.id()}) }}">
-          {{ node.localgov_news_categories.entity.label() }}
-        </a>
-      </span>
-      {% endif %}
+<article{{ attributes.addClass(classes) }}>
 
-    </div>
-
-    <h1>{{ label }}</h1>
+  <div class="news-article__metadata">
+    <time datetime="{{ node.localgov_news_date()|date("U") }}" class="news-article__metadata-item news-article__metadata--date">
+      {{ node.localgov_news_date()|date("j F Y") }}
+    </time>
+    {% if not node.localgov_news_categories.isEmpty() %}
+      {% for item in node.localgov_news_categories %}
+        <ul class="news-article__metadata-item news-article__metadata--categories">
+          <li class="news-article__category">
+            <a href="{{ path('entity.taxonomy_term.canonical', {'taxonomy_term': item.entity.id()}) }}">
+              {{ item.entity.label() }}
+            </a>
+          </li>
+        </ul>
+      {% endfor %}
+    {% endif %}
   </div>
 
-  {{ content }}
+  <h1{{ title_attributes }}>{{ label }}</h1>
+
+  <div{{ content_attributes.addClass('node__content') }}>
+    {{ content }}
+  </div>
+
 </article>

--- a/templates/node--localgov-news-article--full.html.twig
+++ b/templates/node--localgov-news-article--full.html.twig
@@ -98,9 +98,11 @@
     {% endif %}
   </div>
 
-  <h1{{ title_attributes }}>{{ label }}</h1>
+  <h1{{ title_attributes.addClass('news-article__title') }}>
+    {{ label }}
+  </h1>
 
-  <div{{ content_attributes.addClass('node__content') }}>
+  <div{{ content_attributes.addClass('news-article__content node__content') }}>
     {{ content }}
   </div>
 

--- a/templates/node--localgov-news-article--full.html.twig
+++ b/templates/node--localgov-news-article--full.html.twig
@@ -89,7 +89,7 @@
         {% for item in node.localgov_news_categories %}
           <li class="news-article__category">
             <a href="/news/search?f[0]=category:{{ item.target_id }}">
-              {{ item.entity.label() }}
+              {{ item.entity.label }}
             </a>
           </li>
         {% endfor %}


### PR DESCRIPTION
This PR:
1. Adds Drupal's `attributes` back in to the template, so we will have access to things like quick edit, and fix a JS error because of it missing.
2. Creates a `news-article` class, so we can correctly use BEM naming conventions
3. Creates a dedicated `news-article__metadata` class and associated classes for the date/categories section
4. Places the date field in a `<time>` tag, adds a `datetime` attribute for screenreaders and other technologies
5. Removes the hard-coding of just one category, since this is a multivalue field
6. Places the category/categories in a `ul` and `li` element, for correct semantics of a list of categories
7. Adds `title_attributes` back to the title element
8. Adds a `news-article__title` class for the title element
9. Places `content_attributes` back with the content variable, instead of at the `article` element
10. Adds a `news-article__content` class to the content area
