### PR TITLE
update news teaser template to follow drupal standards a little better

### DIFF
--- a/templates/node--localgov-news-article--teaser.html.twig
+++ b/templates/node--localgov-news-article--teaser.html.twig
@@ -70,19 +70,44 @@
 #}
 {%
   set classes = [
-  'node',
-  'node--type-' ~ node.bundle|clean_class,
-  not node.isPublished() ? 'node--unpublished',
-  view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
-]
+    'teaser',
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
 %}
+
 <article{{ attributes.addClass(classes) }}>
-    {{ content.localgov_news_image }}
-  <div{{ content_attributes.addClass('node__content') }}>
-    <h3>
+  
+  {% if node.localgov_news_image.value %}
+    <div class="teaser__image">
+      {{ content.localgov_news_image }}
+    </div>
+  {% endif %}
+  
+  <div{{ content_attributes.addClass('teaser__content node__content') }}>
+    <h3{{ title_attributes.addClass('teaser__title') }}>
       <a href="{{ url }}">{{ label }}</a>
     </h3>
     <p>{{ node.body.summary }}</p>
-    <div class="localgov_news_date">{{ content.localgov_news_date }}</div>
+
+    {% if node.localgov_news_date.value %}
+      <time datetime="{{ node.localgov_news_date.value|date("U") }}" class="teaser__date">
+        {{ content.localgov_news_date }}
+      </time>
+    {% endif %}
   </div>
+
 </article>
+
+{% block content_variable %}
+  {#
+    This allows the cache_context to bubble up for us, without having to
+    individually list every field in
+    {{ content|without('field_name', 'field_other_field', 'field_etc') }}
+  #}
+  {% set catch_cache = content|render %}
+{% endblock %}


### PR DESCRIPTION
Before I write the contents of this PR, I think we should not have templates per view mode per content type. The point of view modes in Drupal is so that we can share design components between content types. 

For this reason, given the layout of the featured news, we should have a "Card" view mode, and use that for _all_ content types when displayed with this view mode, via a `node--card.html.twig` template.

Then we have another view mode for teaser - with all content types using this having the same layout (beside some extra/fewer fields), using `node--teaser.html.twig` rather than content type specific templates.

With that being the case, this PR:
1. Adds `promoted` and `sticky` classes back to the classes array, in case anyone wants them in the future
2. Adds a dedicated `teaser` class to the classes array, so we can use BEM naming convention for the other elements here
2. Puts an `if` condition around the image field render, in case we ever have a situation whereby this becomes an optional field
3. Adds a BEM class around the image - `teaser__image`
4. Adds a BEM class around the content - `teaser__content`
5. Checks that there is a value in the date field before printing it
6. Adds a BEM class around the date - `teaser__date`
7. Puts the date in a `time` element with a `datetime of when the node was created`
8. Adds a small check for the cache metadata to be able to bubble up correctly

I think all the elements of this template should really be moved to the `localgov-skeleton` theme, and be agnostic so can be used by any content type.