### PR TITLE
Follow-up to #33 #35 (for #32): Workflow support for 'promote checkbox'

### DIFF
--- a/src/NewsExtraFieldDisplay.php
+++ b/src/NewsExtraFieldDisplay.php
@@ -126,17 +126,40 @@ class NewsExtraFieldDisplay implements ContainerInjectionInterface {
       ($form_display = $form_state->get('form_display')) &&
       ($form_display->getComponent('localgov_news_newsroom_promote'))
     ) {
+
+      $form_object = $form_state->getFormObject();
+      $node = $form_object->getEntity();
+      /** @var \Drupal\content_moderation\ModerationInformationInterface $moderation_info */
+      $moderation_information = \Drupal::service('content_moderation.moderation_information');
+      if (empty($moderation_information) || !$moderation_information->isModeratedEntity($node)) {
+        $visible = [
+          ":input[name='status[value]']" => [
+            'checked' => TRUE,
+          ],
+        ];
+      }
+      else {
+        $workflow = $moderation_information->getWorkflowForEntity($node);
+        $type_plugin = $workflow->getTypePlugin();
+        $transitions = $type_plugin->getTransitions();
+        foreach ($transitions as $transition) {
+          $state = $transition->to();
+          if ($state->isPublishedState()) {
+            $published[] = [":input[name='moderation_state[0][state]']" => ['value' => $state->id()]];
+            $published[] = 'or';
+          }
+        }
+        array_pop($published);
+        $visible = [$published];
+      }
+
       $form['localgov_news_newsroom_promote'] = [
         '#title' => $this->t('Promote on newsroom'),
         '#type' => 'checkbox',
         '#description' => $this->t("Add to promoted news in the newsroom. If there is already the maximum number of promoted news items the last will be removed to make space."),
-        '#default_value' => self::articlePromotedStatus($form_state->getFormObject()),
+        '#default_value' => self::articlePromotedStatus($form_object),
         '#states' => [
-          'visible' => [
-            ":input[name='status[value]']" => [
-              'checked' => TRUE,
-            ],
-          ],
+          'visible' => $visible,
         ],
       ];
       $form['actions']['submit']['#submit'][] = [self::class, 'articleSubmit'];

--- a/src/NewsExtraFieldDisplay.php
+++ b/src/NewsExtraFieldDisplay.php
@@ -40,6 +40,8 @@ class NewsExtraFieldDisplay implements ContainerInjectionInterface {
    *
    * @param \Drupal\Core\Block\BlockManagerInterface $block_manager
    *   Block plugin manager.
+   * @param \Drupal\content_moderation\ModerationInformationInterface|null $moderation_information
+   *   The moderation information service.
    */
   public function __construct(BlockManagerInterface $block_manager, ModerationInformationInterface $moderation_information = NULL) {
     $this->blockManager = $block_manager;


### PR DESCRIPTION
Adds some support for workflow published states for #32.

Doesn't break the tests for #32 so should still be fine without ; Will need tests requiring localgov workflow (?) to test against. The entity reference field itself is still not perfect for workflow, but that's a separate step.