### PR TITLE
Add lgd-teaser-list class to news search and news list views

### DIFF
--- a/config/install/views.view.localgov_news_list.yml
+++ b/config/install/views.view.localgov_news_list.yml
@@ -261,7 +261,7 @@ display:
           plugin_id: numeric
       display_extenders: {  }
       use_ajax: false
-      css_class: view--teasers
+      css_class: 'view--teasers lgd-teaser-list'
       filter_groups:
         operator: AND
         groups:

--- a/config/install/views.view.localgov_news_search.yml
+++ b/config/install/views.view.localgov_news_search.yml
@@ -4,11 +4,11 @@ dependencies:
   config:
     - field.storage.node.localgov_news_categories
     - search_api.index.localgov_news
-  module:
-    - search_api
   enforced:
     module:
       - localgov_news
+  module:
+    - search_api
 id: localgov_news_search
 label: 'News search'
 module: views
@@ -225,6 +225,7 @@ display:
       relationships: {  }
       arguments: {  }
       display_extenders: {  }
+      css_class: lgd-teaser-list
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
Closes #39 This PR:

- Adds the `lgd-teaser-list` class to the news search and news lists views, to enable localgov_base styling