### PR TITLE
Upgrade Facets to 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "drupal/entity_browser": "^2.5",
-        "drupal/entity_reference_facet_link": "dev-entity_reference_facet_link-3254358",
+        "drupal/entity_reference_facet_link": "dev-3254358-can-not-update",
         "drupal/facets": "^2.0",
         "drupal/field_group": "~3.0",
         "drupal/pathauto": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     "minimum-stability": "dev",
     "require": {
         "drupal/entity_browser": "^2.5",
-        "drupal/entity_reference_facet_link": "^1.0@beta",
-        "drupal/facets": "^2.0 as ^1.0.0-beta1",
+        "drupal/facets": "^2.0",
+        "drupal/entity_reference_facet_link": "^2.0.0-beta",
         "drupal/field_group": "~3.0",
         "drupal/pathauto": "~1.0",
         "drupal/search_api": "^1.17",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/entity_browser": "^2.5",
         "drupal/entity_reference_facet_link": "^1.0.0-beta6",
-        "drupal/facets": "^1.5",
+        "drupal/facets": "^2.0",
         "drupal/field_group": "~3.0",
         "drupal/pathauto": "~1.0",
         "drupal/search_api": "^1.17",

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,15 @@
     "homepage": "https://github.com/localgovdrupal/localgov_news",
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://git.drupalcode.org/issue/entity_reference_facet_link-3254358.git"
+        }
+    ],
     "require": {
         "drupal/entity_browser": "^2.5",
-        "drupal/entity_reference_facet_link": "^1.0.0-beta6",
+        "drupal/entity_reference_facet_link": "dev-entity_reference_facet_link-3254358",
         "drupal/facets": "^2.0",
         "drupal/field_group": "~3.0",
         "drupal/pathauto": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -5,16 +5,10 @@
     "homepage": "https://github.com/localgovdrupal/localgov_news",
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://git.drupalcode.org/issue/entity_reference_facet_link-3254358.git"
-        }
-    ],
     "require": {
         "drupal/entity_browser": "^2.5",
-        "drupal/entity_reference_facet_link": "dev-3254358-can-not-update",
-        "drupal/facets": "^2.0",
+        "drupal/entity_reference_facet_link": "^1.0@beta",
+        "drupal/facets": "^2.0 as ^1.0.0-beta1",
         "drupal/field_group": "~3.0",
         "drupal/pathauto": "~1.0",
         "drupal/search_api": "^1.17",

--- a/localgov_news.info.yml
+++ b/localgov_news.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov News: Core'
 description: Base module shared for LocalGov News with news article content type and optional Newsroom sub-module.
-core_version_requirement: ^8.9 || ^9
+core_version_requirement: ^9
 type: module
 package: LocalGov Drupal
 


### PR DESCRIPTION
Drops support for Drupal 8.x and PHP 7.1

See also:
 * https://github.com/localgovdrupal/localgov_openreferral/pull/23
 *  https://github.com/localgovdrupal/localgov_directories/pull/176