### PR TITLE
Don't create a newsroom by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ Provides the pages and navigation for presenting news articles. A part of the Lo
 - By default the search and facet blocks for news are shown in the view mode for the newsroom, and as blocks on all pages under the `news/*` path if you have the localgov_base theme installed. Alternatively, add, or change the configuration for, these three blocks from the Drupal block layout admin page.
 
 ## Usage
-- Newsroom
-  - A default News '/news' newsroom will be installed. Articles by default go into this.
-  - It is possible to post more newsrooms for articles to go into.
+- Create a Newsroom
+  - Create one, or more, newsrooms for articles to go into.
   - A newsroom has a field in which it is possible to select 3 featured articles.
   - The Featured News block shows up to 3 featured articles - if there are fewer than 3 explicitly featured articles the remainder will be filled by the latest promoted articles (if any).
   - The Article List block will show 10 articles per page, excluding those in the featured block.

--- a/localgov_news.install
+++ b/localgov_news.install
@@ -5,7 +5,6 @@
  * Install, update and uninstall functions for the localgov_news module.
  */
 
-use Drupal\node\Entity\Node;
 use Drupal\user\RoleInterface;
 
 /**
@@ -14,21 +13,5 @@ use Drupal\user\RoleInterface;
 function localgov_news_install() {
   if (\Drupal::moduleHandler()->moduleExists('user')) {
     user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['use search_api_autocomplete for localgov_news_search']);
-  }
-
-  // Just in case there's something newsroom already there check.
-  $existing_newsroom = \Drupal::entityQuery('node')
-    ->condition('type', 'localgov_newsroom')
-    ->count()
-    ->accessCheck(FALSE)
-    ->execute();
-  // If there isn't create the default.
-  if (!$existing_newsroom) {
-    $newsroom = Node::create([
-      'type' => 'localgov_newsroom',
-      'title' => t('News'),
-      'uid' => 1,
-    ]);
-    $newsroom->save();
   }
 }

--- a/tests/src/Functional/NewsPageTest.php
+++ b/tests/src/Functional/NewsPageTest.php
@@ -60,6 +60,13 @@ class NewsPageTest extends BrowserTestBase {
       'administer node fields',
     ]);
     $this->nodeStorage = $this->container->get('entity_type.manager')->getStorage('node');
+
+    // Newsroom.
+    $this->createNode([
+      'title' => 'News',
+      'type' => 'localgov_newsroom',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
   }
 
   /**

--- a/tests/src/Functional/NewsSearchTest.php
+++ b/tests/src/Functional/NewsSearchTest.php
@@ -61,7 +61,13 @@ class NewsSearchTest extends BrowserTestBase {
       'value' => 'Science is the search for truth, that is the effort to understand the world: it involves the rejection of bias, of dogma, of revelation, but not the rejection of morality.',
       'summary' => 'One of the greatest joys known to man is to take a flight into ignorance in search of knowledge.',
     ];
-    $newsroom = $this->getNodeByTitle('News');
+
+    // Newsroom.
+    $newsroom = $this->createNode([
+      'title' => 'News',
+      'type' => 'localgov_newsroom',
+      'status' => NodeInterface::PUBLISHED,
+    ]);
     $this->createNode([
       'title' => 'Test News Article',
       'body' => $body,


### PR DESCRIPTION
 * Following the same pattern as Directories.
 * For Microsites it's not desired to have a node created on the master
   site.