### PR TITLE
2.2.3 release 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,8 @@
         "drupal/schema_metatag": "^2.1",
         "localgovdrupal/localgov_topics": "^1.0",
         "localgovdrupal/localgov_core": "^2.0"
+    },
+    "require-dev": {
+        "localgovdrupal/localgov_search": "^1.1"
     }
 }

--- a/config/install/core.entity_view_display.node.localgov_news_article.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_news_article.search_result.yml
@@ -10,29 +10,28 @@ dependencies:
     - field.field.node.localgov_news_article.localgov_news_related
     - field.field.node.localgov_news_article.localgov_newsroom
     - node.type.localgov_news_article
-  enforced:
-    module:
-      - localgov_news
   module:
     - text
     - user
+  enforced:
+    module:
+      - localgov_news
 id: node.localgov_news_article.search_result
 targetEntityType: node
 bundle: localgov_news_article
 mode: search_result
 content:
-  body:
-    label: hidden
-    type: text_default
-    weight: 0
+  search_api_excerpt:
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
+  body: true
+  content_moderation_control: true
   field_media_image: true
   links: true
   localgov_news_categories: true
   localgov_news_date: true
   localgov_news_related: true
   localgov_newsroom: true
-  search_api_excerpt: true

--- a/config/install/core.entity_view_display.node.localgov_newsroom.search_result.yml
+++ b/config/install/core.entity_view_display.node.localgov_newsroom.search_result.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.search_result
+    - field.field.node.localgov_newsroom.localgov_newsroom_featured
+    - node.type.localgov_newsroom
+  module:
+    - text
+    - user
+  enforced:
+    module:
+      - localgov_news
+id: node.localgov_newsroom.search_result
+targetEntityType: node
+bundle: localgov_newsroom
+mode: search_result
+content:
+  search_api_excerpt:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  content_moderation_control: true
+  links: true
+  localgov_news_facets: true
+  localgov_news_search: true
+  localgov_newsroom_all_view: true
+  localgov_newsroom_featured: true

--- a/tests/src/Functional/NewsSearchTest.php
+++ b/tests/src/Functional/NewsSearchTest.php
@@ -43,6 +43,8 @@ class NewsSearchTest extends BrowserTestBase {
    */
   public static $modules = [
     'localgov_news',
+    'localgov_search',
+    'localgov_search_db',
   ];
 
   /**
@@ -74,6 +76,7 @@ class NewsSearchTest extends BrowserTestBase {
       'type' => 'localgov_news_article',
       'status' => NodeInterface::PUBLISHED,
       'localgov_newsroom' => ['target_id' => $newsroom->id()],
+      'localgov_news_date' => ['value' => '2020-06-01'],
     ]);
 
     $this->drupalLogout();
@@ -85,20 +88,30 @@ class NewsSearchTest extends BrowserTestBase {
    */
   public function testNewsSearch() {
 
-    drupal_flush_all_caches();
     // Defaults to be on 'news' page.
     $this->drupalGet('news');
-    $this->submitForm(['edit-search-api-fulltext' => 'dogma'], 'Apply');
+    $this->submitForm(['edit-search-api-fulltext' => 'dogma'], 'Apply', 'views-exposed-form-localgov-news-search-page-search-news');
     $this->assertSession()->pageTextContains('Test News Article');
 
     // Defaults to be on 'news' path page.
-    $this->drupalGet('news/2021/test-news-article');
-    $this->submitForm(['edit-search-api-fulltext' => 'dogma'], 'Apply');
+    $this->drupalGet("news/2020/test-news-article");
+    $this->submitForm(['edit-search-api-fulltext' => 'dogma'], 'Apply', 'views-exposed-form-localgov-news-search-page-search-news');
     $this->assertSession()->pageTextContains('Test News Article');
 
-    $this->drupalGet('news/2021/test-news-article');
-    $this->submitForm(['edit-search-api-fulltext' => 'xyzzy'], 'Apply');
+    $this->drupalGet("news/2020/test-news-article");
+    $this->submitForm(['edit-search-api-fulltext' => 'xyzzy'], 'Apply', 'views-exposed-form-localgov-news-search-page-search-news');
     $this->assertSession()->pageTextNotContains('Test News Article');
+  }
+
+  /**
+   * LocalGov Search integration.
+   */
+  public function testLocalgovSearch() {
+    $this->drupalGet('search', ['query' => ['s' => 'bias+dogma+revelation']]);
+    $this->assertSession()->pageTextContains('Test News Article');
+    $this->assertSession()->responseContains('<strong>bias</strong>');
+    $this->assertSession()->responseContains('<strong>dogma</strong>');
+    $this->assertSession()->responseContains('<strong>revelation</strong>');
   }
 
 }


### PR DESCRIPTION
* Add search result highlight to search result highlight display

Fix #70

This is for sitewide search, not the news search which uses the teaser display mode.

Usual cavet about using search_api as dependency applies. (If not using search_api, the search result display will be blank)

Note: Whilst a newsroom search result display mode is included, there is no search index for newsroom as there is no content to search.

* Fix tests for news search to use current year in path alias.

* Use fixed date for news item; add tests for LocalGov Search integration. (#74)

Co-authored-by: Finn <finn@agile.coop>
Co-authored-by: ekes <ekes@iskra.net>