### PR TITLE
Adding newsroom and news articles to sitemap

### DIFF
--- a/localgov_news.install
+++ b/localgov_news.install
@@ -14,4 +14,19 @@ function localgov_news_install() {
   if (\Drupal::moduleHandler()->moduleExists('user')) {
     user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['use search_api_autocomplete for localgov_news_search']);
   }
+
+  // Install default config for simple_sitemap, as this does not appear to work
+  // in the config/optional folder.
+  // Discussed on https://www.drupal.org/project/simple_sitemap/issues/3156080
+  if (\Drupal::moduleHandler()->moduleExists('simple_sitemap')) {
+    $generator = \Drupal::service('simple_sitemap.entity_manager');
+    $generator->setBundleSettings('node', 'localgov_newsroom', [
+      'index' => TRUE,
+      'priority' => 0.5,
+    ]);
+    $generator->setBundleSettings('node', 'localgov_news_article', [
+      'index' => TRUE,
+      'priority' => 0.5,
+    ]);
+  }
 }

--- a/localgov_news.install
+++ b/localgov_news.install
@@ -10,7 +10,12 @@ use Drupal\user\RoleInterface;
 /**
  * Implements hook_install().
  */
-function localgov_news_install() {
+function localgov_news_install($is_syncing) {
+
+  if ($is_syncing) {
+    return;
+  }
+
   if (\Drupal::moduleHandler()->moduleExists('user')) {
     user_role_grant_permissions(RoleInterface::ANONYMOUS_ID, ['use search_api_autocomplete for localgov_news_search']);
   }


### PR DESCRIPTION
Add newsroom and news articles to sitemap.

There is a config file for this, but it doesn't work. I've replicated the same approach used to fix this for other content types and this seems to do the trick.

Closes #37