### PR TITLE
Add RSS feed for the news feed

### DIFF
--- a/config/install/views.view.localgov_news_list.yml
+++ b/config/install/views.view.localgov_news_list.yml
@@ -303,6 +303,43 @@ display:
     display_plugin: feed
     position: 3
     display_options:
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: localgov_newsroom
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: 'not found'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: true
+          title: '{{ arguments.nid }}'
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
       filters:
         status:
           id: status
@@ -338,8 +375,30 @@ display:
         type: node_rss
         options: {  }
       defaults:
+        relationships: false
+        arguments: false
         filters: false
         filter_groups: false
+      relationships:
+        reverse__node__localgov_newsroom_featured:
+          id: reverse__node__localgov_newsroom_featured
+          table: node_field_data
+          field: reverse__node__localgov_newsroom_featured
+          relationship: none
+          group_type: group
+          admin_label: localgov_newsroom_featured
+          entity_type: node
+          plugin_id: entity_reverse
+          required: false
+        localgov_newsroom:
+          id: localgov_newsroom
+          table: node__localgov_newsroom
+          field: localgov_newsroom
+          relationship: none
+          group_type: group
+          admin_label: 'localgov_newsroom: Content'
+          plugin_id: standard
+          required: false
       display_extenders: {  }
       path: news/%node/feed.rss
       displays:

--- a/config/install/views.view.localgov_news_list.yml
+++ b/config/install/views.view.localgov_news_list.yml
@@ -5,7 +5,6 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.storage.node.localgov_news_date
     - node.type.localgov_news_article
-    - node.type.localgov_newsroom
   module:
     - datetime
     - node
@@ -127,23 +126,21 @@ display:
           exposed: false
           granularity: second
       arguments:
-        nid:
-          id: nid
-          table: node_field_data
-          field: nid
-          relationship: localgov_newsroom
+        localgov_newsroom_target_id:
+          id: localgov_newsroom_target_id
+          table: node__localgov_newsroom
+          field: localgov_newsroom_target_id
+          relationship: none
           group_type: group
           admin_label: ''
-          entity_type: node
-          entity_field: nid
-          plugin_id: node_nid
-          default_action: ignore
+          plugin_id: numeric
+          default_action: 'not found'
           exception:
             value: all
             title_enable: false
             title: All
-          title_enable: true
-          title: '{{ arguments.nid }}'
+          title_enable: false
+          title: ''
           default_argument_type: fixed
           default_argument_options:
             argument: ''
@@ -156,16 +153,11 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: true
+          specify_validation: false
           validate:
-            type: 'entity:node'
+            type: none
             fail: 'not found'
-          validate_options:
-            bundles:
-              localgov_newsroom: localgov_newsroom
-            access: false
-            operation: view
-            multiple: 0
+          validate_options: {  }
           break_phrase: false
           not: false
       filters:
@@ -268,18 +260,8 @@ display:
           entity_type: node
           plugin_id: entity_reverse
           required: false
-        localgov_newsroom:
-          id: localgov_newsroom
-          table: node__localgov_newsroom
-          field: localgov_newsroom
-          relationship: none
-          group_type: group
-          admin_label: 'localgov_newsroom: Content'
-          plugin_id: standard
-          required: false
       css_class: 'view--teasers lgd-teaser-list'
       use_ajax: false
-      show_admin_links: true
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -312,6 +294,63 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  feed_1:
+    id: feed_1
+    display_title: Feed
+    display_plugin: feed
+    position: 3
+    display_options:
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            localgov_news_article: localgov_news_article
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      row:
+        type: node_rss
+        options: {  }
+      defaults:
+        filters: false
+        filter_groups: false
+      display_extenders: {  }
+      path: news/%node/feed.rss
+      displays:
+        all_news: all_news
+        default: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -536,32 +575,3 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.localgov_news_date'
-  rss_feed:
-    id: rss_feed
-    display_title: Feed
-    display_plugin: feed
-    position: 3
-    display_options:
-      style:
-        type: rss
-        options:
-          grouping: {  }
-          uses_fields: false
-          description: ''
-      row:
-        type: node_rss
-        options: {  }
-      display_extenders: {  }
-      path: news/%node/feed.rss
-      displays:
-        all_news: all_news
-        default: '0'
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - 'user.node_grants:view'
-        - user.permissions
-      tags: {  }

--- a/config/install/views.view.localgov_news_list.yml
+++ b/config/install/views.view.localgov_news_list.yml
@@ -5,6 +5,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.storage.node.localgov_news_date
     - node.type.localgov_news_article
+    - node.type.localgov_newsroom
   module:
     - datetime
     - node
@@ -126,21 +127,23 @@ display:
           exposed: false
           granularity: second
       arguments:
-        localgov_newsroom_target_id:
-          id: localgov_newsroom_target_id
-          table: node__localgov_newsroom
-          field: localgov_newsroom_target_id
-          relationship: none
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: localgov_newsroom
           group_type: group
           admin_label: ''
-          plugin_id: numeric
-          default_action: 'not found'
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: ignore
           exception:
             value: all
             title_enable: false
             title: All
-          title_enable: false
-          title: ''
+          title_enable: true
+          title: '{{ arguments.nid }}'
           default_argument_type: fixed
           default_argument_options:
             argument: ''
@@ -153,11 +156,16 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: false
+          specify_validation: true
           validate:
-            type: none
+            type: 'entity:node'
             fail: 'not found'
-          validate_options: {  }
+          validate_options:
+            bundles:
+              localgov_newsroom: localgov_newsroom
+            access: false
+            operation: view
+            multiple: 0
           break_phrase: false
           not: false
       filters:
@@ -260,8 +268,18 @@ display:
           entity_type: node
           plugin_id: entity_reverse
           required: false
+        localgov_newsroom:
+          id: localgov_newsroom
+          table: node__localgov_newsroom
+          field: localgov_newsroom
+          relationship: none
+          group_type: group
+          admin_label: 'localgov_newsroom: Content'
+          plugin_id: standard
+          required: false
       css_class: 'view--teasers lgd-teaser-list'
       use_ajax: false
+      show_admin_links: true
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -294,29 +312,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - 'user.node_grants:view'
-        - user.permissions
-      tags: {  }
-  feed_1:
-    id: feed_1
-    display_title: Feed
-    display_plugin: feed
-    position: 3
-    display_options:
-      row:
-        type: node_rss
-        options: {  }
-      display_extenders: {  }
-      path: news/%node/feed.rss
-      displays:
-        all_news: all_news
-        default: '0'
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -541,3 +536,32 @@ display:
         - user.permissions
       tags:
         - 'config:field.storage.node.localgov_news_date'
+  rss_feed:
+    id: rss_feed
+    display_title: Feed
+    display_plugin: feed
+    position: 3
+    display_options:
+      style:
+        type: rss
+        options:
+          grouping: {  }
+          uses_fields: false
+          description: ''
+      row:
+        type: node_rss
+        options: {  }
+      display_extenders: {  }
+      path: news/%node/feed.rss
+      displays:
+        all_news: all_news
+        default: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/config/install/views.view.localgov_news_list.yml
+++ b/config/install/views.view.localgov_news_list.yml
@@ -18,46 +18,70 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: true
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+      title: 'News list'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: full
         options:
-          items_per_page: 10
           offset: 0
-          id: 0
+          items_per_page: 10
           total_pages: null
+          id: 0
           tags:
-            previous: '‹ Previous'
             next: 'Next ›'
+            previous: '‹ Previous'
             first: '« First'
             last: 'Last »'
           expose:
@@ -69,87 +93,100 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-      style:
-        type: default
-      row:
-        type: 'entity:node'
+      exposed_form:
+        type: basic
         options:
-          view_mode: teaser
-      fields:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          entity_type: node
-          entity_field: title
-          label: ''
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        localgov_news_date_value:
+          id: localgov_news_date_value
+          table: node__localgov_news_date
+          field: localgov_news_date_value
           relationship: none
           group_type: group
           admin_label: ''
-          exclude: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
+          plugin_id: datetime
+          order: DESC
+          expose:
+            label: ''
+          exposed: false
+          granularity: second
+      arguments:
+        localgov_newsroom_target_id:
+          id: localgov_newsroom_target_id
+          table: node__localgov_newsroom
+          field: localgov_newsroom_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: 'not found'
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            localgov_news_article: localgov_news_article
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            localgov_news_article: localgov_news_article
+          group: 1
           expose:
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         localgov_newsroom_featured_target_id:
           id: localgov_newsroom_featured_target_id
           table: node__localgov_newsroom_featured
@@ -157,6 +194,7 @@ display:
           relationship: reverse__node__localgov_newsroom_featured
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           operator: empty
           value:
             min: ''
@@ -178,9 +216,9 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -193,25 +231,24 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: numeric
-      sorts:
-        localgov_news_date_value:
-          id: localgov_news_date_value
-          table: node__localgov_news_date
-          field: localgov_news_date_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          plugin_id: datetime
-      title: 'News list'
-      header: {  }
-      footer: {  }
-      empty: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: true
+          replica: false
+          query_tags: {  }
       relationships:
         reverse__node__localgov_newsroom_featured:
           id: reverse__node__localgov_newsroom_featured
@@ -220,52 +257,14 @@ display:
           relationship: none
           group_type: group
           admin_label: localgov_newsroom_featured
-          required: false
           entity_type: node
           plugin_id: entity_reverse
-      arguments:
-        localgov_newsroom_target_id:
-          id: localgov_newsroom_target_id
-          table: node__localgov_newsroom
-          field: localgov_newsroom_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: 'not found'
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: fixed
-          default_argument_options:
-            argument: ''
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-          plugin_id: numeric
-      display_extenders: {  }
-      use_ajax: false
+          required: false
       css_class: 'view--teasers lgd-teaser-list'
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      use_ajax: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -277,14 +276,17 @@ display:
         - user.permissions
       tags: {  }
   all_news:
-    display_plugin: embed
     id: all_news
     display_title: 'All news'
+    display_plugin: embed
     position: 1
     display_options:
-      display_extenders: {  }
+      defaults:
+        link_display: true
+        link_url: true
       display_description: 'All news (excluding featured)'
       display_comment: 'Query is altered in localgov_news.module.'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -295,116 +297,57 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  newsroom_entity_reference:
-    display_plugin: entity_reference
-    id: newsroom_entity_reference
-    display_title: 'Newsroom Entity Reference'
+  feed_1:
+    id: feed_1
+    display_title: Feed
+    display_plugin: feed
     position: 3
     display_options:
+      row:
+        type: node_rss
+        options: {  }
       display_extenders: {  }
-      display_description: 'Restrict articles that can be referenced to the articles in the newsroom.'
-      arguments:
-        localgov_newsroom_target_id:
-          id: localgov_newsroom_target_id
-          table: node__localgov_newsroom
-          field: localgov_newsroom_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: ignore
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: node
-          default_argument_options: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-          plugin_id: numeric
-      defaults:
-        arguments: false
-        filters: false
-        filter_groups: false
-        fields: false
-        relationships: false
-      pager:
-        type: none
-        options:
-          offset: 0
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          value:
-            localgov_news_article: localgov_news_article
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      path: news/%node/feed.rss
+      displays:
+        all_news: all_news
+        default: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  newsroom_entity_reference:
+    id: newsroom_entity_reference
+    display_title: 'Newsroom Entity Reference'
+    display_plugin: entity_reference
+    position: 3
+    display_options:
       fields:
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -414,9 +357,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -434,6 +381,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -490,7 +438,81 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: none
+        options:
+          offset: 0
+      arguments:
+        localgov_newsroom_target_id:
+          id: localgov_newsroom_target_id
+          table: node__localgov_newsroom
+          field: localgov_newsroom_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            localgov_news_article: localgov_news_article
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            title: title
+            localgov_news_date: localgov_news_date
       row:
         type: entity_reference
         options:
@@ -500,13 +522,15 @@ display:
             localgov_news_date: localgov_news_date
           separator: ' - '
           hide_empty: false
-      style:
-        type: entity_reference
-        options:
-          search_fields:
-            title: title
-            localgov_news_date: localgov_news_date
+      defaults:
+        relationships: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
       relationships: {  }
+      display_description: 'Restrict articles that can be referenced to the articles in the newsroom.'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/install/views.view.localgov_news_list.yml
+++ b/config/install/views.view.localgov_news_list.yml
@@ -125,6 +125,22 @@ display:
             label: ''
           exposed: false
           granularity: second
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+          granularity: second
       arguments:
         localgov_newsroom_target_id:
           id: localgov_newsroom_target_id

--- a/src/NewsExtraFieldDisplay.php
+++ b/src/NewsExtraFieldDisplay.php
@@ -314,6 +314,12 @@ class NewsExtraFieldDisplay implements ContainerInjectionInterface {
       if ($element['key'] == 'pubDate') {
         $node->rss_elements[$delta]['value'] = $node->localgov_news_date?->date?->format('r') ?? $node->rss_elements[$delta]['value'];
       }
+
+      // Remove dc:creator.
+      // @todo Allow this to be overridden.
+      if ($element['key'] == 'dc:creator') {
+        unset($node->rss_elements[$delta]);
+      }
     }
   }
 

--- a/src/NewsExtraFieldDisplay.php
+++ b/src/NewsExtraFieldDisplay.php
@@ -110,6 +110,9 @@ class NewsExtraFieldDisplay implements ContainerInjectionInterface {
     if ($display->getComponent('localgov_news_facets')) {
       $build['localgov_news_facets'] = $this->getFacetsBlock();
     }
+    if ($node->getType() == 'localgov_news_article' && $view_mode == 'rss') {
+      $this->rssEntityView($node);
+    }
   }
 
   /**
@@ -297,6 +300,21 @@ class NewsExtraFieldDisplay implements ContainerInjectionInterface {
     }
 
     return $blocks;
+  }
+
+  /**
+   * RSS entity view customisations.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node being rendered in RSS entity view mode.
+   */
+  protected function rssEntityView(NodeInterface $node) {
+    foreach ($node->rss_elements as $delta => $element) {
+      // Replace created pubDate with News Published Date.
+      if ($element['key'] == 'pubDate') {
+        $node->rss_elements[$delta]['value'] = $node->localgov_news_date?->date?->format('r') ?? $node->rss_elements[$delta]['value'];
+      }
+    }
   }
 
 }

--- a/tests/src/Functional/NewsPageTest.php
+++ b/tests/src/Functional/NewsPageTest.php
@@ -265,6 +265,10 @@ class NewsPageTest extends BrowserTestBase {
     $this->drupalGet('news/' . date('Y') . '/news-article-1');
     $this->assertSession()->pageTextContains('News article 1');
     $this->assertSession()->pageTextContains($body);
+
+    // Flush cache needed to access the news view with the addition of the rss
+    // feed. Otherwise: Route view.localgov_news_list.feed_1 does not exist.
+    drupal_flush_all_caches();
     $this->drupalGet('news');
     $this->assertSession()->elementContains('css', 'div.view--teasers', 'News article 1');
 


### PR DESCRIPTION
FIx #99

Amends the news list view to provide an rss feed at /node/%node/feed.rss
and provides a link on the news list.
