### PR TITLE
Remove link_attributes dependancy (was : Update link_attributes to 2.x branch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/facets": "^2.0",
         "drupal/entity_reference_facet_link": "^2.0.0-beta",
         "drupal/field_group": "~3.0",
-        "drupal/link_attributes": "^1.2",
+        "drupal/link_attributes": "^2.1",
         "drupal/pathauto": "~1.0",
         "drupal/search_api": "^1.17",
         "drupal/search_api_autocomplete": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "drupal/facets": "^2.0",
         "drupal/entity_reference_facet_link": "^2.0.0-beta",
         "drupal/field_group": "~3.0",
-        "drupal/link_attributes": "^2.1",
         "drupal/pathauto": "~1.0",
         "drupal/search_api": "^1.17",
         "drupal/search_api_autocomplete": "^1.3",

--- a/localgov_news.info.yml
+++ b/localgov_news.info.yml
@@ -20,7 +20,6 @@ dependencies:
   - entity_reference_facet_link:entity_reference_facet_link
   - facets:facets
   - field_group:field_group
-  - link_attributes:link_attributes
   - localgov_core:localgov_core
   - localgov_core:localgov_media
   - localgov_topics:localgov_topics


### PR DESCRIPTION
Fix #115

Set min version to 2.1 as 1.x branch unsuported.

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

~~Upgrades to 2.x branch~~
Now it removes the module.

## How to test

Along with https://github.com/localgovdrupal/localgov_services/pull/276 there should no longer be an unsupported module message.

## How can we measure success?

News links still can have custom attributes / classes.
No more unsupported module error messages.

Update: But there aren't any news links.

## Have we considered potential risks?

Standard module major upgrade risks apply.

## Images

n/a

## Accessibility

n/a