### PR TITLE
Remove config on uninstall

### DIFF
--- a/config/install/field.storage.node.localgov_newsroom.yml
+++ b/config/install/field.storage.node.localgov_newsroom.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_news
   module:
     - node
 id: node.localgov_newsroom

--- a/config/install/pathauto.pattern.localgov_newsroom.yml
+++ b/config/install/pathauto.pattern.localgov_newsroom.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - localgov_news
   module:
     - node
 id: localgov_newsroom

--- a/localgov_news.install
+++ b/localgov_news.install
@@ -35,3 +35,21 @@ function localgov_news_install($is_syncing) {
     ]);
   }
 }
+
+/**
+ * Implements hook_uninstall().
+ */
+function localgov_news_uninstall($is_syncing) {
+  if (!$is_syncing) {
+    $config_keys = [
+      'field.storage.node.localgov_newsroom',
+      'pathauto.pattern.localgov_newsroom',
+    ];
+    $config_factory = \Drupal::service('config.factory');
+    foreach ($config_keys as $config_key) {
+      if ($editable = $config_factory->getEditable($config_key)) {
+        $editable->delete();
+      }
+    }
+  }
+}

--- a/localgov_news.install
+++ b/localgov_news.install
@@ -35,15 +35,3 @@ function localgov_news_install($is_syncing) {
     ]);
   }
 }
-
-/**
- * Implements hook_uninstall().
- */
-function localgov_news_uninstall($is_syncing) {
-  if (!$is_syncing) {
-    $config_factory = \Drupal::service('config.factory');
-    if ($editable = $config_factory->getEditable('pathauto.pattern.localgov_newsroom')) {
-      $editable->delete();
-    }
-  }
-}

--- a/localgov_news.install
+++ b/localgov_news.install
@@ -41,15 +41,9 @@ function localgov_news_install($is_syncing) {
  */
 function localgov_news_uninstall($is_syncing) {
   if (!$is_syncing) {
-    $config_keys = [
-      'field.storage.node.localgov_newsroom',
-      'pathauto.pattern.localgov_newsroom',
-    ];
     $config_factory = \Drupal::service('config.factory');
-    foreach ($config_keys as $config_key) {
-      if ($editable = $config_factory->getEditable($config_key)) {
-        $editable->delete();
-      }
+    if ($editable = $config_factory->getEditable('pathauto.pattern.localgov_newsroom')) {
+      $editable->delete();
     }
   }
 }


### PR DESCRIPTION
Relates to https://github.com/localgovdrupal/localgov_news/issues/94 . Remove Pathauto settings, and add a field dependency on the module so that it uninstalls correctly.