### PR TITLE
fix: drop drupal 10.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
+        "drupal/core": "^10.2",
         "drupal/entity_browser": "^2.5",
         "drupal/facets": "^2.0",
         "drupal/entity_reference_facet_link": "^2.0.0-beta",

--- a/localgov_news.info.yml
+++ b/localgov_news.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov News: Core'
 description: Base module shared for LocalGov News with news article content type and optional Newsroom sub-module.
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10.2
 type: module
 package: LocalGov Drupal
 

--- a/tests/src/FunctionalJavascript/PromotedNewsWidgetTest.php
+++ b/tests/src/FunctionalJavascript/PromotedNewsWidgetTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\localgov_news\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\node\NodeInterface;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 
@@ -16,10 +16,7 @@ use Drupal\Tests\node\Traits\NodeCreationTrait;
 class PromotedNewsWidgetTest extends WebDriverTestBase {
 
   use ContentTypeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
   use NodeCreationTrait;
 
   /**


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Drop Drupal 10.1 support, 10.1 was EoL June 2024

Change record: https://www.drupal.org/node/3401941