### PR TITLE
fix: upgrade schema_metatag to recommended version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "drupal/pathauto": "~1.0",
         "drupal/search_api": "^1.17",
         "drupal/search_api_autocomplete": "^1.3",
-        "drupal/schema_metatag": "^2.1",
+        "drupal/schema_metatag": "^3.0.3",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_topics": "^1.0"
     },


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Upgrade schema_metatag contrib module to the version recommended by the maintainer https://www.drupal.org/project/schema_metatag.

This also gives support for Drupal core ^9 || ^10 || ^11

This is dependent on this PR https://github.com/localgovdrupal/localgov_core/pull/248

## How to test
```
composer require --with-all-dependencies localgovdrupal/localgov_core:"dev-fix/2.x/upgrade-metatag as 2.13.7" localgovdrupal/localgov_news:"dev-fix/2.x/update-schema-metatag as 2.3.8"
```