### PR TITLE
sets featured news to use card view mode

### DIFF
--- a/config/install/core.entity_view_display.node.localgov_news_article.localgov_card.yml
+++ b/config/install/core.entity_view_display.node.localgov_news_article.localgov_card.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - facets.facet.localgov_news_category
+    - core.entity_view_mode.node.localgov_card
     - field.field.node.localgov_news_article.body
     - field.field.node.localgov_news_article.field_media_image
     - field.field.node.localgov_news_article.localgov_news_categories
@@ -12,36 +12,31 @@ dependencies:
     - node.type.localgov_news_article
   module:
     - datetime
-    - entity_reference_facet_link
     - text
     - user
   enforced:
     module:
       - localgov_news
-id: node.localgov_news_article.default
+id: node.localgov_news_article.localgov_card
 targetEntityType: node
 bundle: localgov_news_article
-mode: default
+mode: localgov_card
 content:
   body:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 1
     region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 0
-    region: content
-  localgov_news_categories:
-    type: entity_reference_facet_link
+  field_media_image:
+    type: entity_reference_entity_view
     label: hidden
     settings:
-      facet: localgov_news_category
+      view_mode: localgov_newsroom_teaser
+      link: false
     third_party_settings: {  }
-    weight: 2
+    weight: 0
     region: content
   localgov_news_date:
     type: datetime_custom
@@ -50,18 +45,11 @@ content:
       timezone_override: ''
       date_format: 'j F Y'
     third_party_settings: {  }
-    weight: 1
-    region: content
-  localgov_news_related:
-    type: entity_reference_entity_view
-    label: hidden
-    settings:
-      view_mode: teaser
-      link: false
-    third_party_settings: {  }
-    weight: 4
+    weight: 2
     region: content
 hidden:
-  field_media_image: true
+  links: true
+  localgov_news_categories: true
+  localgov_news_related: true
   localgov_newsroom: true
   search_api_excerpt: true

--- a/config/install/core.entity_view_display.node.localgov_newsroom.default.yml
+++ b/config/install/core.entity_view_display.node.localgov_newsroom.default.yml
@@ -4,44 +4,44 @@ dependencies:
   config:
     - field.field.node.localgov_newsroom.localgov_newsroom_featured
     - node.type.localgov_newsroom
+  module:
+    - user
   enforced:
     module:
       - localgov_news
-  module:
-    - user
 id: node.localgov_newsroom.default
 targetEntityType: node
 bundle: localgov_newsroom
 mode: default
 content:
   links:
+    settings: {  }
+    third_party_settings: {  }
     weight: 4
     region: content
+  localgov_news_facets:
     settings: {  }
     third_party_settings: {  }
-  localgov_news_facets:
     weight: 3
     region: content
+  localgov_news_search:
     settings: {  }
     third_party_settings: {  }
-  localgov_news_search:
     weight: 2
     region: content
+  localgov_newsroom_all_view:
     settings: {  }
     third_party_settings: {  }
-  localgov_newsroom_all_view:
     weight: 1
     region: content
-    settings: {  }
-    third_party_settings: {  }
   localgov_newsroom_featured:
     type: entity_reference_entity_view
-    weight: 0
-    region: content
     label: visually_hidden
     settings:
-      view_mode: teaser
+      view_mode: localgov_card
       link: false
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   search_api_excerpt: true


### PR DESCRIPTION
Closes #129

## What does this change?

Uses card view mode for featured news items in newsrooms.

Might be best to hold off on merging this until [the card template](https://github.com/localgovdrupal/localgov_base/pull/659) is merged in LocalGov Base.

## How to test

- In LocalGov Base, checkout this branch `feature/568-card-template` if it has not already been merged to LocalGov Base.
- Create a newsroom
- Add some news articles to the featured section
- They should now be using the Card view mode + template + CSS

## How can we measure success?

More people start using the card view mode for cards instead of trying to bend the teaser template to their needs.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.