### PR TITLE
sets news blocks to appear in sidebar_first

### DIFF
--- a/config/optional/block.block.localgov_base_localgov_news_category.yml
+++ b/config/optional/block.block.localgov_base_localgov_news_category.yml
@@ -10,7 +10,7 @@ dependencies:
     - localgov_base
 id: localgov_base_localgov_news_category
 theme: localgov_base
-region: sidebar_second
+region: sidebar_first
 weight: 0
 provider: null
 plugin: 'facet_block:localgov_news_category'

--- a/config/optional/block.block.localgov_base_localgov_news_date.yml
+++ b/config/optional/block.block.localgov_base_localgov_news_date.yml
@@ -10,7 +10,7 @@ dependencies:
     - localgov_base
 id: localgov_base_localgov_news_date
 theme: localgov_base
-region: sidebar_second
+region: sidebar_first
 weight: 0
 provider: null
 plugin: 'facet_block:localgov_news_date'

--- a/config/optional/block.block.localgov_base_localgov_news_search.yml
+++ b/config/optional/block.block.localgov_base_localgov_news_search.yml
@@ -13,7 +13,7 @@ dependencies:
     - localgov_base
 id: localgov_base_localgov_news_search
 theme: localgov_base
-region: sidebar_second
+region: sidebar_first
 weight: -2
 provider: null
 plugin: 'views_exposed_filter_block:localgov_news_search-page_search_news'

--- a/config/optional/block.block.localgov_scarfolk_localgov_news_category.yml
+++ b/config/optional/block.block.localgov_scarfolk_localgov_news_category.yml
@@ -10,7 +10,7 @@ dependencies:
     - localgov_scarfolk
 id: localgov_scarfolk_localgov_news_category
 theme: localgov_scarfolk
-region: sidebar_second
+region: sidebar_first
 weight: 0
 provider: null
 plugin: 'facet_block:localgov_news_category'

--- a/config/optional/block.block.localgov_scarfolk_localgov_news_date.yml
+++ b/config/optional/block.block.localgov_scarfolk_localgov_news_date.yml
@@ -10,7 +10,7 @@ dependencies:
     - localgov_scarfolk
 id: localgov_scarfolk_localgov_news_date
 theme: localgov_scarfolk
-region: sidebar_second
+region: sidebar_first
 weight: 0
 provider: null
 plugin: 'facet_block:localgov_news_date'

--- a/config/optional/block.block.localgov_scarfolk_localgov_news_search.yml
+++ b/config/optional/block.block.localgov_scarfolk_localgov_news_search.yml
@@ -13,7 +13,7 @@ dependencies:
     - localgov_scarfolk
 id: localgov_scarfolk_localgov_news_search
 theme: localgov_scarfolk
-region: sidebar_second
+region: sidebar_first
 weight: -2
 provider: null
 plugin: 'views_exposed_filter_block:localgov_news_search-page_search_news'


### PR DESCRIPTION
Closes #126 

## What does this change?

Sets the news filter blocks to appear in `sidebar_first` instead of `sidebar_second`.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.