### PR TITLE
feat: drupal 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "drupal/core": "^10.2",
+        "drupal/core": "^10.2 || ^11.0",
         "drupal/entity_browser": "^2.5",
         "drupal/facets": "^2.0",
         "drupal/entity_reference_facet_link": "^2.0.0-beta",

--- a/localgov_news.info.yml
+++ b/localgov_news.info.yml
@@ -1,6 +1,6 @@
 name: 'LocalGov News: Core'
 description: Base module shared for LocalGov News with news article content type and optional Newsroom sub-module.
-core_version_requirement: ^10.2
+core_version_requirement: ^10.2 || ^11
 type: module
 package: LocalGov Drupal
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #122 

## How to test

```bash
composer require localgovdrupal/localgov_news:"dev-feature/drupal-11-support as 2.3.10"
```

Failures are stylelint, not related to D11 support.

## How can we measure success?

Module works with both D10 and D11