### PR TITLE
feat: upgrade field_group to version 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/entity_browser": "^2.5",
         "drupal/facets": "^2.0",
         "drupal/entity_reference_facet_link": "^2.0.0-beta",
-        "drupal/field_group": "~3.0",
+        "drupal/field_group": "^4.0",
         "drupal/pathauto": "~1.0",
         "drupal/search_api": "^1.17",
         "drupal/search_api_autocomplete": "^1.3",


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This upgrades field_group to v4, this brings UX bug fixes and some general bug fixes.

The maintainer says this about v4;

> Switching to SemVer. Besides that, 4.0.0 is just a bugfix and feature release of 8.x-3.x.

So should be safe to bump the version.

field_group v3 is due to be marked as unsupported soon see https://www.drupal.org/project/field_group/issues/3520770#comment-16083966

## How to test

Testing will mean also updating to the following modules which also have PRs for field_group v4

- localgov_core
- localgov_services
- localgov_paragraphs
- localgov_news