### PR TITLE
Allow upgrade to facets 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/core": "^10.2 || ^11.0",
         "drupal/entity_browser": "^2.5",
-        "drupal/facets": "^2.0",
+        "drupal/facets": "^2.0 || ^3.0",
         "drupal/entity_reference_facet_link": "^2.0.0-beta",
         "drupal/field_group": "^4.0",
         "drupal/pathauto": "~1.0",


### PR DESCRIPTION
Fix #139

This is the pair to https://github.com/localgovdrupal/localgov_directories/pull/413

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

This is to allow news facets to optionally upgrade to facets 3. (Note: this will default unless there are composer restrictions that require facets 2, which could be accomplished in a root composer.json).

This is just the upgrade, it won't switch on views exposed filters facets, just allows those sites that wish to proceed to do so.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

Verify facets 3 installs and no breakages with the news facets filters on the right.

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Upgrade works

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

There's some change in facets 3 from 2 that wasn't anticipated.

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

n/a

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

n/a