### PR TITLE
Replace internal NodeForm reference with ContentEntityInterface

### DIFF
--- a/src/NewsExtraFieldDisplay.php
+++ b/src/NewsExtraFieldDisplay.php
@@ -142,7 +142,7 @@ class NewsExtraFieldDisplay implements ContainerInjectionInterface {
       // Must be a content entity form on a node.
       assert($form_object instanceof ContentEntityFormInterface);
       $node = $form_object->getEntity();
-      assert($node instanceof $node);
+      assert($node instanceof NodeInterface);
 
       if (empty($this->moderationInformation) || !$this->moderationInformation->isModeratedEntity($node)) {
         $visible = [

--- a/src/NewsExtraFieldDisplay.php
+++ b/src/NewsExtraFieldDisplay.php
@@ -4,6 +4,7 @@ namespace Drupal\localgov_news;
 
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\ContentEntityFormInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -11,7 +12,6 @@ use Drupal\Core\Plugin\PluginBase;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\content_moderation\ModerationInformationInterface;
 use Drupal\node\Entity\Node;
-use Drupal\node\NodeForm;
 use Drupal\node\NodeInterface;
 use Drupal\views\Views;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -138,42 +138,45 @@ class NewsExtraFieldDisplay implements ContainerInjectionInterface {
     ) {
 
       $form_object = $form_state->getFormObject();
-      if ($form_object instanceof NodeForm) {
-        $node = $form_object->getEntity();
-        if (empty($this->moderationInformation) || !$this->moderationInformation->isModeratedEntity($node)) {
-          $visible = [
-            ":input[name='status[value]']" => [
-              'checked' => TRUE,
-            ],
-          ];
-        }
-        else {
-          $workflow = $this->moderationInformation->getWorkflowForEntity($node);
-          $type_plugin = $workflow->getTypePlugin();
-          $transitions = $type_plugin->getTransitions();
-          $published = [];
-          foreach ($transitions as $transition) {
-            $state = $transition->to();
-            if ($state->isPublishedState()) {
-              $published[] = [":input[name='moderation_state[0][state]']" => ['value' => $state->id()]];
-              $published[] = 'or';
-            }
-          }
-          array_pop($published);
-          $visible = [$published];
-        }
 
-        $form['localgov_news_newsroom_promote'] = [
-          '#title' => $this->t('Promote on newsroom'),
-          '#type' => 'checkbox',
-          '#description' => $this->t("Add to promoted news in the newsroom. If there is already the maximum number of promoted news items the last will be removed to make space."),
-          '#default_value' => self::articlePromotedStatus($form_object),
-          '#states' => [
-            'visible' => $visible,
+      // Must be a content entity form on a node.
+      assert($form_object instanceof ContentEntityFormInterface);
+      $node = $form_object->getEntity();
+      assert($node instanceof $node);
+
+      if (empty($this->moderationInformation) || !$this->moderationInformation->isModeratedEntity($node)) {
+        $visible = [
+          ":input[name='status[value]']" => [
+            'checked' => TRUE,
           ],
         ];
-        $form['actions']['submit']['#submit'][] = [self::class, 'articleSubmit'];
       }
+      else {
+        $workflow = $this->moderationInformation->getWorkflowForEntity($node);
+        $type_plugin = $workflow->getTypePlugin();
+        $transitions = $type_plugin->getTransitions();
+        $published = [];
+        foreach ($transitions as $transition) {
+          $state = $transition->to();
+          if ($state->isPublishedState()) {
+            $published[] = [":input[name='moderation_state[0][state]']" => ['value' => $state->id()]];
+            $published[] = 'or';
+          }
+        }
+        array_pop($published);
+        $visible = [$published];
+      }
+
+      $form['localgov_news_newsroom_promote'] = [
+        '#title' => $this->t('Promote on newsroom'),
+        '#type' => 'checkbox',
+        '#description' => $this->t("Add to promoted news in the newsroom. If there is already the maximum number of promoted news items the last will be removed to make space."),
+        '#default_value' => self::articlePromotedStatus($form_object),
+        '#states' => [
+          'visible' => $visible,
+        ],
+      ];
+      $form['actions']['submit']['#submit'][] = [self::class, 'articleSubmit'];
     }
   }
 
@@ -191,7 +194,7 @@ class NewsExtraFieldDisplay implements ContainerInjectionInterface {
     if (
       $form_state->getValue('status') &&
       ($form_object = $form_state->getFormObject()) &&
-      ($form_object instanceof NodeForm) &&
+      ($form_object instanceof ContentEntityFormInterface) &&
       ($article = $form_object->getEntity()) &&
       ($newsroom = $article->localgov_newsroom->entity)
     ) {
@@ -211,13 +214,13 @@ class NewsExtraFieldDisplay implements ContainerInjectionInterface {
   /**
    * Check for NodeForm Entity article and if it is promoted in Newsroom.
    *
-   * @param \Drupal\node\NodeForm $form_object
-   *   Node form object.
+   * @param \Drupal\Core\Entity\ContentEntityFormInterface $form_object
+   *   Content entity (Node) form object.
    *
    * @return bool
    *   TRUE if there is an article and it is promoted on newsroom.
    */
-  public static function articlePromotedStatus(NodeForm $form_object) {
+  public static function articlePromotedStatus(ContentEntityFormInterface $form_object) {
     if (
       ($article = $form_object->getEntity()) &&
       ($newsroom = $article->localgov_newsroom->entity)


### PR DESCRIPTION
Fix #141

<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Replaces the if check for NodeForm with assertions that this is a ContentEntityFormInterface and that the underlying entity is a NodeInterface.

This fixes the 'Promote on newsroom' option at the bottom of localgov_news_article on Drupal 11.2.

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

Install on Drupal 11.2 and check promote to newsroom is present when editing a News article.

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Drupal 11 tests should start passing

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

Extensions to this might be using NodeForm pattern (though those will now break as this is an internal class that has moved).

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

<img width="766" alt="Screenshot 2025-06-16 at 5 03 31 pm" src="https://github.com/user-attachments/assets/62ab5fdd-8749-4bb9-a814-b0fd61c8d4a6" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

n/a
