### PR TITLE
Check if newsroom is required before printing message

### DIFF
--- a/localgov_news.module
+++ b/localgov_news.module
@@ -76,14 +76,15 @@ function localgov_news_form_alter(array &$form, FormStateInterface $form_state, 
  * Implements hook_field_widget_complete_form_alter().
  */
 function localgov_news_field_widget_complete_form_alter(&$field_widget_complete_form, FormStateInterface $form_state, $context) {
-  // If the localgov_newsroom field only has one newsroom to choose, just select
-  // it and hide the field.
+  // If the localgov_newsroom field is a required field and only has one
+  // newsroom to choose, just select it and hide the field.
   $field_definition = $context['items']->getFieldDefinition();
   if ($field_definition->getName() == 'localgov_newsroom' && isset($field_widget_complete_form['widget']['#options'])) {
     $options = $field_widget_complete_form['widget']['#options'];
 
-    // If there are no newsrooms display a warning.
-    if (count($options) == 1 && isset($options['_none'])) {
+    // If the newsroom field is a required field, but there are no newsrooms
+    // created yet, display a warning.
+    if ($field_definition->isRequired() && count($options) == 1 && isset($options['_none'])) {
       $create_newsroom_path = 'localgov_newsroom';
       if (\Drupal::moduleHandler()->moduleExists('localgov_microsites_group')) {
         // @phpstan-ignore-next-line Ignore the next line as this is only present on microsites.
@@ -98,7 +99,9 @@ function localgov_news_field_widget_complete_form_alter(&$field_widget_complete_
     }
 
     unset($options['_none']);
-    if (count($options) == 1) {
+    // If there is no options or only one option left,
+    // select it automatically, and hide the field.
+    if (count($options) <= 1) {
       $field_widget_complete_form['widget']['#value'] = key($options);
       $field_widget_complete_form['widget']['#type'] = 'value';
     }

--- a/localgov_news.module
+++ b/localgov_news.module
@@ -99,12 +99,15 @@ function localgov_news_field_widget_complete_form_alter(&$field_widget_complete_
     }
 
     unset($options['_none']);
-    // If there is no options or only one option left,
-    // select it automatically, and hide the field.
-    if (count($options) <= 1) {
+    // 1. If the newsroom field "is" required and we now only have 1 option
+    //    left, choose it and hide the field.
+    // 2. If the newsroom field "is not" required, but we have no newsrooms
+    //    available, hide the field.
+    if (($field_definition->isRequired() && count($options) == 1) || (!$field_definition->isRequired() && count($options) == 0)) {
       $field_widget_complete_form['widget']['#value'] = key($options);
       $field_widget_complete_form['widget']['#type'] = 'value';
     }
+
   }
 
   // Restrict the featured articles to articles in the newsroom.


### PR DESCRIPTION
Closes #148 

## What does this change?

1. Checks if the newsroom field is required before printing the "Please create a newsroom" message.
2. If the field is required and there is only 1 option choose it.
3. If the field is not required and there are no newsrooms, hide the field.

## How to test

Check the field visibility when there is a newsroom and not a newsroom, for both the field being required and not required.

## How can we measure success?

If the newsroom is not required, editors don't see the "Create newsroom" message.

## Have we considered potential risks?

If the field is not required and there are no newsrooms, _maybe_ editors won't know that they _could have_ put articles in newsrooms.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.