### PR TITLE
Fixes prefixes (subdirectory, language) being included in parent path pattern for other instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Provides the pages and navigation for presenting news articles. A part of the Lo
   - The Categories field uses the LocalGov Topics vocabulary. Edit the field to use alternative or additional vocabularies.
   - Image is a required field - authors can upload a new image or select an image from the media library.
   - Article nodes are not promoted - see the Featured News section below.
-  - Article aliases are: [node:localgov_newsroom:entity:url:relative]/[node:localgov_news_date:date:html_year]/[node:title] thus prefacing the path with that of their newsroom, followed by year and sanitised title.
+  - Article aliases are: [node:localgov_newsroom:entity:url:path]/[node:localgov_news_date:date:html_year]/[node:title] thus prefacing the path with that of their newsroom, followed by year and sanitised title.
 
 ## Structured data
 - The Schema.org Metatag module is used to generate structured data for individual news articles. This is rendered as JSON LD in the `<head>` element.

--- a/config/install/pathauto.pattern.localgov_news.yml
+++ b/config/install/pathauto.pattern.localgov_news.yml
@@ -9,7 +9,7 @@ dependencies:
 id: localgov_news
 label: News
 type: 'canonical_entities:node'
-pattern: '[node:localgov_newsroom:entity:url:relative]/[node:localgov_news_date:date:html_year]/[node:title]'
+pattern: '[node:localgov_newsroom:entity:url:path]/[node:localgov_news_date:date:html_year]/[node:title]'
 selection_criteria:
   fa93e7c4-4c6f-4ed1-988b-ce660e1d6292:
     id: 'entity_bundle:node'

--- a/localgov_news.post_update.php
+++ b/localgov_news.post_update.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for LocalGov News.
+ */
+
+use Drupal\pathauto\Entity\PathautoPattern;
+use Drupal\pathauto\PathautoPatternInterface;
+
+/**
+ * Update pathauto patterns to avoid inclusion of subdirectory, language, etc.
+ */
+function localgov_news_post_update_pathauto_parent(): void {
+  $alias = PathautoPattern::load('localgov_news');
+  if ($alias instanceof PathautoPatternInterface &&
+    $alias->getPattern() == '[node:localgov_newsroom:entity:url:relative]/[node:localgov_news_date:date:html_year]/[node:title]'
+  ) {
+    $alias->setPattern('[node:localgov_newsroom:entity:url:path]/[node:localgov_news_date:date:html_year]/[node:title]');
+    $alias->save();
+  }
+}


### PR DESCRIPTION
See https://github.com/localgovdrupal/localgov_services/issues/335#issuecomment-3461396195 and https://github.com/localgovdrupal/localgov_services/issues/335